### PR TITLE
Add support for 64bit systems when looking for libmodsecurity

### DIFF
--- a/build/find_libmodsec.m4
+++ b/build/find_libmodsec.m4
@@ -18,10 +18,14 @@ if test -z "$V3PATH"; then
            /usr/local/sbin \
            /usr/local/bin \
            /usr/sbin \
-           /usr/bin;
+           /usr/bin \
+           /usr;
   do
     if test -f "$i/lib/libmodsecurity.so"; then
       V3LIB="$i/lib/"
+    fi
+    if test -f "$i/lib64/libmodsecurity.so"; then
+      V3LIB="$i/lib64/"
     fi
     if test -f "$i/include/modsecurity/modsecurity.h"; then
       V3INCLUDE="$i/include/"


### PR DESCRIPTION
Hi,
configure fails on 64bit system since find_libsec macros does not look in /usr and <?>/lib64/

NB. This also will help modsec v3 packaging.