### PR TITLE
Fix duplicate HTTP protocol version string

### DIFF
--- a/src/mod_security3.c
+++ b/src/mod_security3.c
@@ -387,6 +387,8 @@ static int hook_request_late(request_rec *r)
         return it;
     }
 #endif
+
+
     msc_process_request_body(msr->t);
     it = process_intervention(msr->t, r);
     if (it != N_INTERVENTION_STATUS)
@@ -464,8 +466,11 @@ static int process_request_headers(request_rec *r, msc_t *msr) {
     /* process uri */
     {
         int it;
-        msc_process_uri(msr->t, r->unparsed_uri, r->method, r->protocol);
+	const char *proto = strdup(r->protocol);
+	if (r->protocol && (r->protocol[0] == 'H'))
+          proto = proto +5;
 
+        msc_process_uri(msr->t, r->unparsed_uri, r->method, proto);
         it = process_intervention(msr->t, r);
         if (it != N_INTERVENTION_STATUS)
         {


### PR DESCRIPTION
Proposed patch to fix an issue on the [REQUEST_PROTOCOL](https://github.com/SpiderLabs/ModSecurity/wiki/Reference-Manual#REQUEST_PROTOCOL) variable and log data:


> ---3pK3I6qx---A--
>
> [05/Nov/2017:03:31:20 -0600] 15098742801.705792 192.168.37.1 56350 localhost.localdomain 0
> ---3pK3I6qx---B--
> POST /index.html?a=b **HTTP/HTTP/1.1**
> Connection: Keep-Alive
> Content-Length: 6
> Content-Type: application/x-www-form-urlencoded
> Host: localhost
> User-Agent: UA
>
> ---3pK3I6qx---C--
>b=boom
>
> ---3pK3I6qx---D--
>
> ---3pK3I6qx---F--
> **HTTP/HTTP/1.1** 403
> Last-Modified: Thu, 02 Nov 2017 02:12:06 GMT
> ETag: "5-55cf683d0502d"
> Accept-Ranges: bytes
>Content-Length: 5


[msc_process_uri()](https://github.com/SpiderLabs/ModSecurity/blob/v3/master/src/transaction.cc#L371) appends the string "HTTP/" to http_version probably because the Nginx connector doesn't.

The problem happens due the fact that in Apache, the[ request_rec:::protocol](https://ci.apache.org/projects/httpd/trunk/doxygen/structrequest__rec.html#ad8737a4518ee6c2f0afe81d5d30b12f0) data field returns the protocol string in the form of "HTTP/1.1".