### PR TITLE
Proposed fix for msc_process_request_body call too early

### DIFF
--- a/src/mod_security3.c
+++ b/src/mod_security3.c
@@ -387,7 +387,8 @@ static int hook_request_late(request_rec *r)
         return it;
     }
 #endif
-    msc_process_request_body(msr->t);
+// FIXME: memsc_append_request_body wasn't called yet. Too early?
+//    msc_process_request_body(msr->t);
     it = process_intervention(msr->t, r);
     if (it != N_INTERVENTION_STATUS)
     {

--- a/src/msc_filters.c
+++ b/src/msc_filters.c
@@ -62,6 +62,9 @@ apr_status_t input_filter(ap_filter_t *f, apr_bucket_brigade *pbbOut,
             return send_error_bucket(msr, f, it);
         }
 
+      // FIXME: Now we should have the body. Is this sane?
+        msc_process_request_body(msr->t);
+
         pbktOut = apr_bucket_heap_create(data, len, 0, c->bucket_alloc);
         APR_BRIGADE_INSERT_TAIL(pbbOut, pbktOut);
         apr_bucket_delete(pbktIn);


### PR DESCRIPTION
Request body was not available on phase 2. Apache Connector debug logs suggested that the data was being appended too late:

<pre>
[9] Appending request body: 8 bytes. Limit set to: 13107200.000000
[4] Starting phase RESPONSE_HEADERS. (SecRules 3)
</pre>

Expected behaviour would be (Nginx Connector debug logs):

[9] Appending request body: 8 bytes. Limit set to: 0.000000
[4] Starting phase REQUEST_BODY. (SecRules 2)