### PR TITLE
Added check for /lib/libmodsecurity.so when --with-libmodsecurity is used

### DIFF
--- a/build/find_libmodsec.m4
+++ b/build/find_libmodsec.m4
@@ -13,6 +13,9 @@ AC_ARG_WITH(libmodsecurity,
     if test -f "${V3PATH}lib/libmodsecurity.so"; then
       V3LIB="${V3PATH}lib/"
     fi
+    if test -f "${V3PATH}include/modsecurity/modsecurity.h"; then
+      V3INCLUDE="${V3PATH}include/"
+    fi
   fi
 ])
 

--- a/build/find_libmodsec.m4
+++ b/build/find_libmodsec.m4
@@ -10,6 +10,9 @@ AC_ARG_WITH(libmodsecurity,
     V3PATH=/usr/local/modsecurity/
   else
     V3PATH="$withval"
+    if test -f "${V3PATH}lib/libmodsecurity.so"; then
+      V3LIB="${V3PATH}lib/"
+    fi
   fi
 ])
 


### PR DESCRIPTION
Add checking for the validity of $V3PATH when --with-libmodsecurity is overridden.  If valid, $V3LIB is set.

Fixes Issue #28 